### PR TITLE
Load frame updates & merge handlabel2d

### DIFF
--- a/example.m
+++ b/example.m
@@ -1,12 +1,12 @@
 %% Example setup for Label3D
-% Label3D is a GUI for manual labeling of 3D keypoints in multiple cameras. 
+% Label3D is a GUI for manual labeling of 3D keypoints in multiple cameras.
 % 
 % Its main features include:
-% 1. Simultaneous viewing of any number of camera views. 
+% 1. Simultaneous viewing of any number of camera views.
 % 2. Multiview triangulation of 3D keypoints.
-% 3. Point-and-click and draggable gestures to label keypoints. 
+% 3. Point-and-click and draggable gestures to label keypoints.
 % 4. Zooming, panning, and other default Matlab gestures
-% 5. Integration with Animator classes. 
+% 5. Integration with Animator classes.
 % 6. Support for editing prelabeled data.
 % 
 % Instructions:
@@ -18,7 +18,7 @@
 % r: reset gui to the first frame and remove Animator restrictions
 % u: reset the current frame to the initial marker positions
 % z: Toggle zoom state
-% p: Show 3d animation plot of the triangulated points. 
+% p: Show 3d animation plot of the triangulated points.
 % backspace: reset currently held node (first click and hold, then
 %            backspace to delete)
 % pageup: Set the selectedNode to the first node
@@ -26,54 +26,112 @@
 % shift+tab: shift the selected node by -1
 % h: print help messages for all Animators
 % shift+s: Save the data to a .mat file
-clear all
+
+% This example assumes that video files are already synchronized
+% I.e. by hardware (arduino). No sync variable used.
+
+clear all;
 close all;
-addpath(genpath('deps'))
-addpath(genpath('skeletons'))
-danncePath = 'Y:/Diego/code/DANNCE';
+addpath(genpath('deps'));
+addpath(genpath('skeletons'));
+
+%% Configuration variables -- SET THESE BEFORE RUNNING
+
+% Path to the DANNCE project folder
+% This folder should contain at least the following folders: "videos", "calibration"
+projectFolder = 'path/to/dannce/project/folder';
+% number of frames to label from each video. Suggested 100-200.
+nFramesToLabel = 100;
 
 %% Load in the calibration parameter data
-projectFolder = fullfile(danncePath,'demo/markerless_mouse_1');
-calibPaths = collectCalibrationPaths(projectFolder);
-params = cellfun(@(X) {load(X)}, calibPaths);
+calibrationPaths = collectCalibrationPaths(projectFolder, 'hires_cam*_params.mat');
+calibrationParams = cellfun(@(X) {load(X)}, calibrationPaths);
 
 %% Load the videos into memory
-vidName = '0.mp4';
-vidPaths = collectVideoPaths(projectFolder,vidName);
-videos = cell(6,1);
-sync = collectSyncPaths(projectFolder, '*.mat');
-sync = cellfun(@(X) {load(X)}, sync);
+videoName = '0.mp4';
+videoPaths = collectVideoPaths(projectFolder, videoName);
 
-% In case the demo folder uses the dannce.mat data format. 
-if isempty(sync)
-    dannce_file = dir(fullfile(projectFolder, '*dannce.mat'));
-    dannce = load(fullfile(dannce_file(1).folder, dannce_file(1).name));
-    sync = dannce.sync;
-    params = dannce.params;
+%% Load video frames into memory
+
+% load one video to determine video dimensions
+vr = VideoReader(videoPaths{1});
+
+nVideos = length(videoPaths);
+
+videoWidth = vr.Width;
+videoHeight = vr.Height;
+nFramesWholeVideo = vr.NumFrames;
+nTotalFrames = nFramesToLabel * nVideos;
+
+% rough estimation for total load time. May vary depending on computer.
+% will be faster if parallel processing is enabled
+estimatedLoadTime = ceil((0.10 * nTotalFrames + 4 * nVideos) / 15) * 15;
+
+% load evenly spaced frames across the whole video
+framesToLabel = round(linspace(1, nFramesWholeVideo, nFramesToLabel));
+
+fprintf(['Reading video frames with the following parameters:\n'...
+    '\tnumber of videos: %d\n'...
+    '\twidth x height: (%d x %d)\n'...
+    '\ttotal number of frames: %d\n'...
+    '\tframes to read per video: %d\n'],...
+    nVideos, videoWidth, videoHeight, nFramesWholeVideo, nFramesToLabel)
+
+fprintf("Estimated load time about %d sec\n\n", estimatedLoadTime)
+
+videos = cell(nVideos, 1);
+
+tic;
+
+parpool("Threads"); % create parallel pool for loading video frames
+% threads is much faster to load than processes
+
+parfor videoIdx = 1 : nVideos
+    fprintf("Started video #%d\n", videoIdx);
+    thisPath = videoPaths{videoIdx};
+    vr = VideoReader(thisPath);
+
+    dest = zeros(videoHeight, videoWidth, 3, nFramesToLabel, 'uint8');
+
+    % Iterate over all framesToLabel
+    for frameIdx = 1 : nFramesToLabel
+        frameNumber = framesToLabel(frameIdx);
+        dest(:, :, :, frameIdx) = vr.read(frameNumber);
+        
+        % Print progress every 20 frames (will be jumbled w. parallel)
+        if mod(frameIdx, 20) == 0
+            fprintf("\tloaded frame #%d of %d. Vid #%d of %d.\n", ...
+                frameIdx, nFramesToLabel, videoIdx, nVideos );
+        end  
+    end
+
+    videos{videoIdx} = dest;
+
+    fprintf("Finished video #%d\n", videoIdx);
 end
 
-framesToLabel = 1:100;
-for nVid = 1:numel(vidPaths)
-    frameInds = sync{nVid}.data_frame(framesToLabel);
-    videos{nVid} = readFrames(vidPaths{nVid}, frameInds+1);
-end
+delete(gcp('nocreate')); % release parallel resources
+
+sEllapsed = toc;
+
+fprintf("Loaded %d frames in %.2f seconds (%.2f fps)\n\n", ...
+    nTotalFrames, sEllapsed, nTotalFrames/sEllapsed);
 
 %% Get the skeleton
-skeleton = load('skeletons/rat16');
-% skeleton = load('com');
+skeleton = load('skeletons/com');
 
 %% Start Label3D
-close all
-labelGui = Label3D(params, videos, skeleton);
-% labelGui = Label3D(params, videos, skeleton, 'sync', sync, 'framesToLabel', framesToLabel);
+close all;
+fprintf("Launching Label3D. May take a few seconds...\n")
+labelGui = Label3D(calibrationParams, videos, skeleton);
 
 %% Check the camera positions
-labelGui.plotCameras       
+% labelGui.plotCameras       
 
 %% If you just wish to view labels, use View 3D
-close all
-viewGui = View3D(params, videos, skeleton);
+% close all
+% viewGui = View3D(calibrationParams, videos, skeleton);
 
 %% You can load both in different ways
-close all;
-View3D()
+% close all;
+% View3D()


### PR DESCRIPTION
Various updates:
1. Merge changes from handlabel2d branch
2. Load frames using native MATLAB VideoReader & read function. As a result:
    * able to run natively on new machines (e.g. apple silicon macs)
    * faster to load frames from across a large video file
3. Optimize loading video frames (pre-allocate arrays & load with parallel threads)
4. Reorganize example script to make it easier to adapt to new project
5. Set save location to project folder when starting label3d via the example script
6. Misc. code & readability improvements